### PR TITLE
[ticket/62689] 500 Internal Server Error when MOD uploaded  [FIX] 

### DIFF
--- a/root/includes/mod_parser.php
+++ b/root/includes/mod_parser.php
@@ -43,9 +43,11 @@ class parser
 		switch ($ext)
 		{
 			case 'xml':
-			default:
+				// fix ticket 62689 only enter parser if it is xml
+				//http://www.phpbb.com/bugs/modteamtools/62689
 				$this->parser = new parser_xml();
 			break;
+			default:
 		}
 	}
 


### PR DESCRIPTION
the parser was always called even for non xml files because of a misplaced default in the switch. 
