### PR TITLE
[ticket/63241] Make sure to only pass a string to add_log()

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,5 +1,8 @@
 AutoMOD Changelog
 
+- Changes since 1.0.l
+ + [Fix] Bug #63241 AutoMOD passes array of MOD titles to add_log()
+
 - Changes since 1.0.0.1
  + [Feature] Ticket #62994 Warn the forum owner/admin if they are installing a MOD targeted at a different phpBB version than their forum is.
  + [Feature] Add ability to handle uninstalling additional modx files

--- a/root/includes/acp/acp_mods.php
+++ b/root/includes/acp/acp_mods.php
@@ -1119,7 +1119,22 @@ class acp_mods
 			$cache->purge();
 
 			// Add log
-			add_log('admin', 'LOG_MOD_ADD', $details['MOD_NAME']);
+			if (is_array($details['MOD_NAME']))
+			{
+				if (isset($details['MOD_NAME']['en']))
+				{
+					$mod_name = $details['MOD_NAME']['en'];
+				}
+				else
+				{
+					$mod_name = array_shift($details['MOD_NAME']);
+				}
+			}
+			else
+			{
+				$mod_name = $details['MOD_NAME'];
+			}
+			add_log('admin', 'LOG_MOD_ADD', $mod_name);
 		}
 		// in this case, we are installing an additional template or language
 		else if (($mod_installed || $force_install) && $parent)
@@ -1462,7 +1477,23 @@ class acp_mods
 			$db->sql_query($sql);
 
 			// Add log
-			add_log('admin', 'LOG_MOD_REMOVE', $details['MOD_NAME']);
+			$mod_name = @unserialize(htmlspecialchars_decode($details['MOD_NAME']));
+			if (is_array($mod_name))
+			{
+				if (isset($mod_name['en']))
+				{
+					$mod_name = $mod_name['en'];
+				}
+				else
+				{
+					$mod_name = array_shift($mod_name);
+				}
+			}
+			else
+			{
+				$mod_name = $details['MOD_NAME'];
+			}
+			add_log('admin', 'LOG_MOD_REMOVE', $mod_name);
 
 			$editor->commit_changes_final('mod_' . $editor->install_time, str_replace(' ', '_', $details['MOD_NAME']));
 		}


### PR DESCRIPTION
We try to pass the English title of the MOD to add_log(). If there is no
English title we'll fall back to the first row of the $details['MOD_NAME']
array.
