### PR TITLE
Clear cache on the uninstallation of a mod 

### DIFF
--- a/root/includes/acp/acp_mods.php
+++ b/root/includes/acp/acp_mods.php
@@ -276,6 +276,7 @@ class acp_mods
 					case 'pre_uninstall':
 					case 'uninstall':
 						$this->uninstall($action, $mod_id, $parent);
+						$cache->purge();
 					break;
 
 					case 'details':


### PR DESCRIPTION
I have found this to be an issue within automod itself in that it doesn't clear the cache on the uninstallation of a mod, hence why the removal of some mods will break a board.

Currently on uninstallation, the original files are restored, however the modified files remain in the cache unless the admin does a manual cache refresh or runs some other uninstall script (database edits) which then refreshes the cache.

Very simple fix to address an issue affecting mod removal as well as a requirement to satisfy mod validation (install / use / uninstall) 
